### PR TITLE
Bump Meilisearch-php to version 0.20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "meilisearch/meilisearch-php": "^0.20",
+        "meilisearch/meilisearch-php": "^0.21",
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "meilisearch/meilisearch-php": "^0.19.1",
+        "meilisearch/meilisearch-php": "^0.20",
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "meilisearch/meilisearch-php": "^0.21",
+        "meilisearch/meilisearch-php": "^0.20",
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.0"
     }


### PR DESCRIPTION
To be compatible with Meilisearch 0.24 the meilisearch-php version 0.20 is required. Unfortunately, I can't upgrade to version 0.21 to be compatible with Meilisearch 0.25 because of too many breaking changes.

