### PR TITLE
Allow newer meilisearch clients

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "meilisearch/meilisearch-php": "0.21.0",
+        "meilisearch/meilisearch-php": "^0.21|^0.22|^0.23",
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.0"
     }


### PR DESCRIPTION
Hi, me again

I also would have the possibility to allow newer MeiliSearch Clients.

If a developer needs an older client, it can still require the client in his root composer.json.

What do you think?