### PR TITLE
Update Authorization Header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ $ export MEILISEARCH_KEY=AWESOMESAUCE
 $ meilisearch
 
 # Generate the keys
-$ curl \
-  -H "X-Meili-API-Key: AWESOMESAUCE" \
+curl \
+  -H 'Authorization: Bearer AWESOMESAUCE' \
   -X GET 'http://localhost:7700/keys'
 ```
 


### PR DESCRIPTION
Since the Authorization with `X-Meili-API-Key` doesn't seem to work anymore, I updated It to Bearer Auth, like written in the docs: https://docs.meilisearch.com/learn/security/master_api_keys.html#communicating-with-a-protected-instance