### PR TITLE
Update for MS v1.0, Statamic 4.0 and Laravel 10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,22 +9,18 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [8.1, 8.0]
-                laravel: [9.*, 8.*]
-                statamic: [3.3.*, 3.2.*, 3.1.*]
+                php: [8.2, 8.1]
+                laravel: [10.*, 9.*]
+                statamic: [4.*, 3.4.*]
                 dependency-version: [prefer-stable]
                 include:
+                    - laravel: 10.*
+                      testbench: 8.*
                     - laravel: 9.*
                       testbench: 7.*
-                    - laravel: 8.*
-                      testbench: 6.*
                 exclude:
-                    -   laravel: 9.*
-                        statamic: 3.2.*
-                    -   laravel: 9.*
-                        statamic: 3.1.*
-                    -   laravel: 8.*
-                        statamic: 3.3.*
+                    -   laravel: 10.*
+                        statamic: 3.4.*
 
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - S${{ matrix.statamic }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Statamic MeiliSearch Driver
 
-***Disclaimer: This search driver is used on a large production site, however MeiliSearch is still changing often, so some problems may occur. Please submit any bugs you find so we can make the driver more stable. If you would like to help maintain the driver, please reach out.***
-
 MeiliSearch driver uses a versioning system that matches MeiliSearch releases to try match releases with any breaking changes. For instance to work with v0.24 you would install the corresponding driver:
 
 ```json

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,15 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1|^8.2",
         "meilisearch/meilisearch-php": "^1.0",
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.0",
-        "illuminate/support": "^8.0|^9.0",
-        "statamic/cms": "^3.1|^3.2|^3.3|^3.4"
+        "illuminate/support": "^9.0|^10.0",
+        "statamic/cms": "^3.4|^4.0"
     },
     "require-dev": {
-        "orchestra/testbench-core": "^6.0|^7.0",
+        "orchestra/testbench-core": "^6.0|^7.0|^8.0",
         "phpunit/phpunit": "^9.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     ],
     "require": {
         "php": "^8.0",
-        "meilisearch/meilisearch-php": "^0.21|^0.22|^0.23|^0.24|^0.25",
+        "meilisearch/meilisearch-php": "^1.0",
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.0",
         "illuminate/support": "^8.0|^9.0",
-        "statamic/cms": "^3.1|^3.2|^3.3"
+        "statamic/cms": "^3.1|^3.2|^3.3|^3.4"
     },
     "require-dev": {
         "orchestra/testbench-core": "^6.0|^7.0",
@@ -50,7 +50,8 @@
     },
     "config": {
         "allow-plugins": {
-            "pixelfear/composer-dist-plugin": true
+            "pixelfear/composer-dist-plugin": true,
+            "php-http/discovery": true
         }
     },
     "extra": {

--- a/src/MeiliSearch/Index.php
+++ b/src/MeiliSearch/Index.php
@@ -80,7 +80,12 @@ class Index extends BaseIndex
     {
         try {
             $this->client->createIndex($this->name, ['primaryKey' => 'id']);
-            $this->getIndex()->updateSettings($this->config['settings'] ?? []);
+
+            if (! isset($this->config['settings'])) {
+                return;
+            }
+
+            $this->getIndex()->updateSettings($this->config['settings']);
         } catch (ApiException $e) {
             $this->handleMeiliSearchException($e, 'createIndex');
         }


### PR DESCRIPTION
Hi there!

We've made some changes to the Statamic MeiliSearch driver to ensure compatibility with MeiliSearch v1.0. One minor issue we encountered was that an empty array could no longer be passed as settings. We've carefully reviewed the [breaking changes in the meilisearch-php package](https://github.com/meilisearch/meilisearch-php/releases/tag/v1.0.0), but couldn't find any more code in your driver that needed to be updated. 

Our testing was limited to a small application, so there may be issues that we haven't yet encountered. If you have a larger application where you can test the driver, we'd greatly appreciate your feedback.

While changing the settings behavior may not be a major update, we also bumped the meilisearch-php version to ensure we're not using an outdated version.

We hope that this will be of help and are happy to receive feedback. 